### PR TITLE
Nodeアップデートに1日の待機期間を追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,7 +42,8 @@
       {
         "matchDepNames": ["node"],
         "matchUpdateTypes": ["minor", "patch"],
-        "automerge": true
+        "automerge": true,
+        "minimumReleaseAge": "1 day"
       },
       {
         "matchPackageNames": ["pnpm"],


### PR DESCRIPTION
## 概要
Nodeのマイナー・パッチバージョンアップについて、リリースから1日経過後にPRが作成されるように設定を追加した。

## 変更内容
- `default.json`のregex packageRulesのnodeルールに`minimumReleaseAge: "1 day"`を追加

## 効果
- Nodeの新バージョンがリリースされても、1日間は様子を見てからPRが作成される
- リリース直後の問題を回避できる
- 1日経過後は既存のautomerge設定により自動マージされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)