### PR TITLE
feat: minimumReleaseAge を 1 day に設定

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "matchUpdateTypes": "patch",


### PR DESCRIPTION
## Summary

- pnpm v11 のデフォルト `minimumReleaseAge=1440`（24h）と揃えるため、Renovate 側にも `minimumReleaseAge: "1 day"` を設定
- 効果: リリース直後のバージョンに対する Renovate PR を 24h 待たせることで、pnpm の lockfile supply-chain policy check（`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`）と衝突しなくなる
- 現状 mypage では Renovate PR が大量に CI fail しており、本変更で解消する見込み

## 背景

pnpm 11 から `minimumReleaseAge` がデフォルト 24h でオン (npm 上の悪性パッケージは大抵 24h 以内に検出・削除されるため、新規バージョンの即時インストールを避けて exposure window を縮める)。一方 Renovate は既定では公開から経過時間に関係なく最新版へ bump を作るため、衝突して CI が落ちる。

参考:
- https://pnpm.io/supply-chain-security
- https://socket.dev/blog/pnpm-11-adds-new-supply-chain-protection-defaults

## Test plan

- [ ] CI（renovate-config-validator）が通ること
- [ ] マージ後、mypage の Renovate PR が再生成されたタイミングで `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` が出なくなるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)